### PR TITLE
Remove unused log4j dependency

### DIFF
--- a/uzaygezen-core/pom.xml
+++ b/uzaygezen-core/pom.xml
@@ -22,11 +22,6 @@
       <version>14.0-rc1</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>


### PR DESCRIPTION
Log4j is not used in the project so it can be removed safely. Moveover,
keeping it as a compile time dependency leads to classpath problems in
project depending on uzaygezen since it gets included transitively.